### PR TITLE
Add pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,3 +5,4 @@
   language: node
   types:
     - svg
+  minimum_pre_commit_version: 1.5.0

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: svglint
+  name: svglint
+  entry: svglint
+  description: Linter for SVGs
+  language: node
+  types:
+    - svg

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 - id: svglint
   name: svglint
-  entry: svglint
+  entry: svglint -C
   description: Linter for SVGs
   language: node
   types:

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 - id: svglint
   name: svglint
-  entry: svglint -C
+  entry: svglint -C  # The `-C` flag is used due to https://github.com/birjj/svglint/issues/56
   description: Linter for SVGs
   language: node
   types:


### PR DESCRIPTION
Hi guys! ✋🏼 

I'm facing a situation where I need to use SVGLint outside of a Javascript project, so I'm using [pre-commit](https://pre-commit.com) to run linters. SVGLint does not have the file to define hooks, so added in this PR.

To use SVGLint as a pre-commit hook:

- Install pre-commit with `pip install pre-commit`
- Create a *.pre-commit-config.yaml* file.
- Define the hook in the file:
   ```yaml
     - repo: https://github.com/birjj/svglint
       rev: v2.1.1
       hooks:
         - id: svglint
   ```
- Run `pre-commit install`

Note that the previous config will not work as the revision `v2.1.1` is not created yet, so this chage will require a new patch or minor version change in SVGLint. To test it, replace the key `repo` by `https://github.com/mondeja/svglint` and `rev` by `pre-commit-hook` (this branch) and run it with `pre-commit run --all-files`. You'll probably need to initialize the CWD as a GIT repo and create an initial commit as well.

All fields are documented at [Creating new hooks in pre-commit.com](https://pre-commit.com/#creating-new-hooks). The key [`minimum_pre_commit_version`](https://pre-commit.com/#hooks-minimum_pre_commit_version) is defined because `node` has been added to pre-commit as a supported language in v1.5.0.