### PR TITLE
refactor: address default import

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -8,13 +8,12 @@ import gui from "../src/cli/gui.js";
 import Logger from "../src/lib/logger.js";
 import SVGLint from "../src/svglint.js";
 // @ts-ignore
-import config from "../src/cli/config.js";
+import { getConfigurationFile } from "../src/cli/config.js";
 import meow from "meow";
 import { chalk } from "../src/cli/util.js";
 import glob from "glob";
 
 const GUI = new gui();
-const { getConfigurationFile } = config;
 
 const logger = Logger("");
 // Pretty logs all errors, then exits

--- a/src/cli/config.js
+++ b/src/cli/config.js
@@ -31,6 +31,6 @@ function getConfigurationFile(filename=".svglintrc.js", folder=process.cwd()) {
     });
 }
 
-export default {
+export {
     getConfigurationFile,
 };

--- a/src/lib/linting.js
+++ b/src/lib/linting.js
@@ -8,7 +8,7 @@
  */
 import { EventEmitter } from "events";
 import path from "path";
-import cheerio from "cheerio";
+import * as cheerio from "cheerio";
 import * as parse from "./parse.js";
 import Reporter from "./reporter.js";
 import Logger from "./logger.js";

--- a/src/lib/linting.js
+++ b/src/lib/linting.js
@@ -9,7 +9,7 @@
 import { EventEmitter } from "events";
 import path from "path";
 import cheerio from "cheerio";
-import parse from "./parse.js";
+import * as parse from "./parse.js";
 import Reporter from "./reporter.js";
 import Logger from "./logger.js";
 

--- a/src/lib/parse.js
+++ b/src/lib/parse.js
@@ -13,50 +13,46 @@ import path from "path";
  * @param {String} source The source to parse
  * @returns {AST} The parsed AST
  */
-function parseSource(source) {
+export function parseSource(source) {
     return normalizeAST(
         sourceToAST(source),
         source
     );
 }
 
-export default {
-    /**
-     * Clones an AST by re-parsing it's source
-     * @param {AST} ast The AST to clone
-     * @returns {AST} The cloned AST
-     */
-    clone(ast) {
-        // @ts-ignore
-        return parseSource(ast.source);
-    },
+/**
+ * Clones an AST by re-parsing it's source
+ * @param {AST} ast The AST to clone
+ * @returns {AST} The cloned AST
+ */
+export function clone(ast) {
+    // @ts-ignore
+    return parseSource(ast.source);
+}
 
-    parseSource,
-
-    /**
-     * Parses the content of a file into an AST
-     * @param {String} file The path of the file in question
-     * @returns {Promise<AST>} The parsed AST
-     */
-    parseFile(file) {
-        const filePath = path.isAbsolute(file)
-            ? file
-            : path.join(process.cwd(), file);
-        return new Promise((res, rej) => {
-            fs.readFile(
-                filePath,
-                "utf8",
-                (err, data) => {
-                    if (err) {
-                        return rej(err);
-                    }
-                    try { return res(parseSource(data)); }
-                    catch (e) { return rej(e); }
+/**
+ * Parses the content of a file into an AST
+ * @param {String} file The path of the file in question
+ * @returns {Promise<AST>} The parsed AST
+ */
+export function parseFile(file) {
+    const filePath = path.isAbsolute(file)
+        ? file
+        : path.join(process.cwd(), file);
+    return new Promise((res, rej) => {
+        fs.readFile(
+            filePath,
+            "utf8",
+            (err, data) => {
+                if (err) {
+                    return rej(err);
                 }
-            );
-        });
-    }
-};
+                try { return res(parseSource(data)); }
+                catch (e) { return rej(e); }
+            }
+        );
+    });
+}
 
 /**
  * @typedef {Object<string,string>} Attributes

--- a/src/svglint.js
+++ b/src/svglint.js
@@ -6,7 +6,7 @@
  *   and converting the user-provided config into an object of rules.
  */
 import Linting from "./lib/linting.js";
-import parse from "./lib/parse.js";
+import * as parse from "./lib/parse.js";
 import loadRule from "./lib/rule-loader.js";
 import Logger from "./lib/logger.js";
 const logger = Logger("");


### PR DESCRIPTION
- Change two instances where the default export is an object of properties and change them into _regular_ exports (following https://github.com/birjj/svglint/pull/41#issuecomment-991701695 and related comments).
- Update the import statement of [`cheerio`](https://cheerio.js.org/) following a deprecation warning on the default export.