### PR TITLE
Address use of deprecated function `fs.exists`

### DIFF
--- a/src/cli/config.js
+++ b/src/cli/config.js
@@ -12,8 +12,8 @@ function getConfigurationFile(filename=".svglintrc.js", folder=process.cwd()) {
         ? filename
         : path.resolve(folder, filename);
     return new Promise((res,rej)=>{
-        fs.exists(resolved, exists=>{
-            if (exists) {
+        fs.access(resolved, fs.constants.F_OK, err=>{
+            if (!err) {
                 // if file exists, finalize
                 res(resolved);
             } else {


### PR DESCRIPTION
The `fs.exists` function is deprecated. `fs.access` is one of the recommended replacements - the other being `fs.stat`, which seems to be doing too much for what is needed.