### PR TITLE
chore(deps): bump actions/checkout from v2 to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write # to comment on Pull Requests included in a release
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Node.js setup

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Node.js setup
         uses: actions/setup-node@v2
         with:
@@ -43,7 +43,7 @@ jobs:
             node-version: 18
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Node.js setup
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
Bumping now due to warnings about deprecated support for Node.js v12-based Actions and Actions using `save-state` and `set-output`.