### PR TITLE
chore(deps): bump minimatch from 3.0.4 to 3.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "rollup": "^2.61.1"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": "^12.20.0 || ^14.13.1 || ^16.0.0 || >=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1137,18 +1137,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/commitizen/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/concat-map": {
@@ -3364,9 +3352,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },


### PR DESCRIPTION
By `npm audit fix`.

Note that this does not affect end-users. Even though `minimatch` is a transitive dependency of `svglint` (through [`glob`](https://github.com/birjj/svglint/blob/8353c59af9d66b19ef0a8e0f93f39e11eea659a4/package.json#L36)):

```shell
# Before (refs/heads/master)
$ npm ls minimatch --omit dev  
svglint@1.0.5 .../svglint
└─┬ glob@7.1.2
  └── minimatch@3.0.4

# After (refs/heads/npm/minimatch-3.1.2)
$ npm ls minimatch --omit dev  
svglint@1.0.5 .../svglint
└─┬ glob@7.1.2
  └── minimatch@3.1.2
```

installing `svglint` fresh will use the latest version of `minimatch`. Existing users of `svglint` can upgrade to a "safe"[^1] version of `minimatch` whenever they want (e.g. by running  `npm audit fix` themselves).

[^1]: I didn't actually look at the vulnerability report for `minimatch`, so I'm not even sure depending on v3.0.4 is "unsafe".