### PR TITLE
Fix checking config.rules when config is null

### DIFF
--- a/src/svglint.js
+++ b/src/svglint.js
@@ -100,7 +100,11 @@ async function normalizeConfig(config) {
         DEFAULT_CONFIG,
         config,
     );
-    defaulted.rules = Object.assign({}, DEFAULT_CONFIG.rules, config.rules);
+    var configrules = {}
+    if ((!config === null) && config.hasOwnProperty('rules')) {
+        configrules = config.rules
+    }
+    defaulted.rules = Object.assign({}, DEFAULT_CONFIG.rules, configrules);
     /** @type NormalizedConfig */
     const outp = {
         rules: await normalizeRules(defaulted.rules),

--- a/src/svglint.js
+++ b/src/svglint.js
@@ -100,9 +100,9 @@ async function normalizeConfig(config) {
         DEFAULT_CONFIG,
         config,
     );
-    var configrules = {}
-    if ((!config === null) && config.hasOwnProperty('rules')) {
-        configrules = config.rules
+    var configrules = {};
+    if (!config === null) {
+        configrules = config.rules;
     }
     defaulted.rules = Object.assign({}, DEFAULT_CONFIG.rules, configrules);
     /** @type NormalizedConfig */


### PR DESCRIPTION
Possible fix for #78.  Not sure I've used 'hasOwnProperty' correctly, but this at least works for me when there is no user config.