### PR TITLE
Address high severity issue by upgrading `fast-xml-parser`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "ansi-regex": "^5.0.1",
         "chalk": "^5.0.0",
         "cheerio": "^1.0.0-rc.6",
-        "fast-xml-parser": "^3.12.13",
+        "fast-xml-parser": "^4.2.4",
         "glob": "^7.1.2",
         "htmlparser2": "^3.9.1",
         "log-update": "^5.0.0",
@@ -2013,15 +2013,24 @@
       "dev": true
     },
     "node_modules/fast-xml-parser": {
-      "version": "3.12.13",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.12.13.tgz",
-      "integrity": "sha512-AW0qennqoHQ65BAMZX/7Y2he6WUz3iqmW4L4/EgMXNvTd5Jfubig50F+N2JVthC5DnkhPWRUp+eO6bbaMCnjHA==",
-      "hasInstallScript": true,
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz",
+      "integrity": "sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==",
+      "funding": [
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "dependencies": {
-        "nimnjs": "^1.3.2"
+        "strnum": "^1.0.5"
       },
       "bin": {
-        "xml2js": "cli.js"
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fastq": {
@@ -3587,25 +3596,6 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "node_modules/nimn_schema_builder": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/nimn_schema_builder/-/nimn_schema_builder-1.1.0.tgz",
-      "integrity": "sha512-DK5/B8CM4qwzG2URy130avcwPev4uO0ev836FbQyKo1ms6I9z/i6EJyiZ+d9xtgloxUri0W+5gfR8YbPq7SheA=="
-    },
-    "node_modules/nimn-date-parser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nimn-date-parser/-/nimn-date-parser-1.0.0.tgz",
-      "integrity": "sha512-1Nf+x3EeMvHUiHsVuEhiZnwA8RMeOBVTQWfB1S2n9+i6PYCofHd2HRMD+WOHIHYshy4T4Gk8wQoCol7Hq3av8Q=="
-    },
-    "node_modules/nimnjs": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/nimnjs/-/nimnjs-1.3.2.tgz",
-      "integrity": "sha512-TIOtI4iqkQrUM1tiM76AtTQem0c7e56SkDZ7sj1d1MfUsqRcq2ZWQvej/O+HBTZV7u/VKnwlKTDugK/75IRPPw==",
-      "dependencies": {
-        "nimn_schema_builder": "^1.0.0",
-        "nimn-date-parser": "^1.0.0"
-      }
-    },
     "node_modules/normalize-package-data": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
@@ -4551,6 +4541,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "node_modules/supports-color": {
       "version": "5.4.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ansi-regex": "^5.0.1",
     "chalk": "^5.0.0",
     "cheerio": "^1.0.0-rc.6",
-    "fast-xml-parser": "^3.12.13",
+    "fast-xml-parser": "^4.2.4",
     "glob": "^7.1.2",
     "htmlparser2": "^3.9.1",
     "log-update": "^5.0.0",

--- a/src/rules/valid.js
+++ b/src/rules/valid.js
@@ -1,5 +1,5 @@
 import Logger from "../lib/logger.js";
-import xmlParser from "fast-xml-parser";
+import { XMLValidator } from "fast-xml-parser";
 const logger = Logger("rule:valid");
 
 /** @typedef {import("../lib/reporter.js")} Reporter */
@@ -34,7 +34,7 @@ export default {
                 logger.debug("Encountered empty SVG. Considering valid");
                 return;
             }
-            const result = xmlParser.validate(ast.source);
+            const result = XMLValidator.validate(ast.source);
             if (result !== true) {
                 reporter.error(result.err.msg, null, ast);
             }


### PR DESCRIPTION
Upgrade [`fast-xml-parser`](https://www.npmjs.com/package/fast-xml-parser) from v3 to v4 in order to address a (according to npm) high severity vulnerability, namely CVE-2023-34104. I did not evaluate the impact of the CVE on this project, but upgrading is easy enough and avoids any potential problems. Plus, staying on the latest available version is always good :)