### PR TITLE
Explicitly import `process`

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,6 +4,7 @@
  * Acts as an interface to the JS API
  */
 import path from "path";
+import process from "process";
 import gui from "../src/cli/gui.js";
 import Logger from "../src/lib/logger.js";
 import SVGLint from "../src/svglint.js";

--- a/src/cli/components/separator.js
+++ b/src/cli/components/separator.js
@@ -1,3 +1,4 @@
+import process from "process";
 import { chalk } from "../util.js";
 const columns = process.stdout.columns || 80;
 

--- a/src/cli/config.js
+++ b/src/cli/config.js
@@ -1,5 +1,6 @@
 import path from "path";
 import fs from "fs";
+import process from "process";
 
 /**
  * Check if a file exists

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Utilities for the CLI.
  */
+import process from "process";
 import { Chalk, supportsColor as chalkSupportsColor } from "chalk";
 import ansiRegex from "ansi-regex";
 

--- a/src/lib/linting.js
+++ b/src/lib/linting.js
@@ -8,6 +8,7 @@
  */
 import { EventEmitter } from "events";
 import path from "path";
+import process from "process";
 import * as cheerio from "cheerio";
 import * as parse from "./parse.js";
 import Reporter from "./reporter.js";

--- a/src/lib/parse.js
+++ b/src/lib/parse.js
@@ -7,6 +7,7 @@
 import Parser from "htmlparser2";
 import fs from "fs";
 import path from "path";
+import process from "process";
 
 /**
  * Parses an SVG source into an AST

--- a/test/api.spec.js
+++ b/test/api.spec.js
@@ -1,5 +1,6 @@
 import expect from "expect";
 import * as path from "path";
+import process from "process";
 import * as url from "url";
 
 import SVGLint from "../src/svglint.js";

--- a/test/attr.spec.js
+++ b/test/attr.spec.js
@@ -1,3 +1,4 @@
+import process from "process";
 import util from "util";
 
 import SVGLint from "../src/svglint.js";

--- a/test/cli.spec.js
+++ b/test/cli.spec.js
@@ -1,4 +1,5 @@
 import path from "path";
+import process from "process";
 
 import { execa } from "execa";
 import expect from "expect";

--- a/test/custom.spec.js
+++ b/test/custom.spec.js
@@ -1,3 +1,4 @@
+import process from "process";
 import util from "util";
 
 import SVGLint from "../src/svglint.js";

--- a/test/elm.spec.js
+++ b/test/elm.spec.js
@@ -1,3 +1,4 @@
+import process from "process";
 import util from "util";
 
 import SVGLint from "../src/svglint.js";

--- a/test/valid.spec.js
+++ b/test/valid.spec.js
@@ -1,3 +1,4 @@
+import process from "process";
 import util from "util";
 
 import SVGLint from "../src/svglint.js";


### PR DESCRIPTION
Closes #72 

---

Explicitly import `process` to avoid using undeclared globals.