### PR TITLE
Use Node.js v20 in continuous integration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           cache: npm
-          node-version: 18
+          node-version: 20
       - name: Install dependencies
         run: npm ci
       - name: Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,16 +32,18 @@ jobs:
           - 14.17.0
           - 16.0.0
           - 18.0.0
+          - 20.0.0
           - 12
           - 14
           - 16
           - 18
           - 19
+          - 20
         include:
           - os: macos-latest
-            node-version: 18
+            node-version: 20
           - os: windows-latest
-            node-version: 18
+            node-version: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           cache: npm
-          node-version: 18
+          node-version: 20
       - name: Install dependencies
         run: npm ci
       - name: Lint


### PR DESCRIPTION
Update the CI to run tests on Node.js v20 (earliest and latest release), update the tests jobs for MacOS and Windows to use Node.js v20 (see also #41, which introduced the test matrix) - and update remaining CI jobs to use Node.js v20 as well.