### PR TITLE
Improve types for `Config`

### DIFF
--- a/src/rules/custom.js
+++ b/src/rules/custom.js
@@ -1,6 +1,7 @@
 import Logger from "../lib/logger.js";
 const logger = Logger("rule:custom");
 
+/** @typedef {import('cheerio').Cheerio<import('domhandler').Document>} Cheerio */
 /** @typedef {import("../lib/reporter.js")} Reporter */
 /** @typedef {import("../lib/parse.js").AST} AST */
 /** @typedef {import("../lib/parse.js").Node} Node */
@@ -11,6 +12,7 @@ const logger = Logger("rule:custom");
  * @param {Reporter} reporter The reporter to report to
  * @param {Cheerio} $ A cheerio representation of the document
  * @param {AST} ast The AST of the document, which we should pass to reporter
+ * @param {Info} info Info related to the current file being linted
  */
 /**
  * @typedef {CustomRule} CustomConfig

--- a/src/svglint.js
+++ b/src/svglint.js
@@ -13,6 +13,9 @@ const logger = Logger("");
 
 /** @typedef {import("./lib/parse.js").AST} AST */
 /** @typedef {import("./lib/rule-loader.js").RuleModule} RuleModule */
+/** @typedef {import("./rules/elm.js").ElmConfig} ElmConfig */
+/** @typedef {import("./rules/attr.js").AttrConfig} AttrConfig */
+/** @typedef {import("./rules/custom.js").CustomConfig} CustomConfig */
 
 /**
  * @typedef RulesConfig
@@ -20,9 +23,9 @@ const logger = Logger("");
  *   a rule config.
  * If the rule config is set to `false`, then the rule is disabled (useful for
  *   e.g. overwriting presets).
- * @property {Object<string, number | boolean>} [elm={}]
- * @property {Array<Object<string, string | boolean | RegExp>>} [attr=[]]
- * @property {Array<Function>} [custom=[]]
+ * @property {ElmConfig} [elm={}]
+ * @property {Array<AttrConfig>} [attr=[]]
+ * @property {Array<CustomConfig>} [custom=[]]
  */
 /**
  * @typedef {Object<string,Function|Function[]>} NormalizedRules

--- a/src/svglint.js
+++ b/src/svglint.js
@@ -15,11 +15,14 @@ const logger = Logger("");
 /** @typedef {import("./lib/rule-loader.js").RuleModule} RuleModule */
 
 /**
- * @typedef {Object<string,any>} RulesConfig
+ * @typedef RulesConfig
  * An object with each key representing a rule name, and each value representing
  *   a rule config.
  * If the rule config is set to `false`, then the rule is disabled (useful for
  *   e.g. overwriting presets).
+ * @property {Object<string, number | boolean>} [elm={}]
+ * @property {Array<Object<string, string | boolean | RegExp>>} [attr=[]]
+ * @property {Array<Function>} [custom=[]]
  */
 /**
  * @typedef {Object<string,Function|Function[]>} NormalizedRules


### PR DESCRIPTION
Not exhaustive but definitely much better than the current typing.

So you can use:

```js
/** @type {import('svglint').Config} */
export default {
  rules: {
    ...
```